### PR TITLE
Updated mal.html

### DIFF
--- a/mal.html
+++ b/mal.html
@@ -193,7 +193,7 @@ this software.
     </div>
     
   </div><!-- / container -->
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
   <script type="text/javascript" src="js/web/jqconsole.min.js"></script>
   <script type="text/javascript" src="js/web/mal.js"></script>
   <script>


### PR DESCRIPTION
Due to the mixed content blocker in current versions of Firefox & Chrome the demo will not work on GitHub Pages. Loading jQuery via https will solve that issue.